### PR TITLE
feat: provide a custom `isSorted` function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,24 @@ CEL standard library and CEL Playground.
 
 Take a look at [all the environment options](eval/eval.go#L31).
 
+### Playground Methods
+
+The following custom methods are available in the playground:
+
+#### isSorted(array)
+
+Returns whether the list is sorted in ascending order.
+```expr
+isSorted([1, 2, 3]) == true
+isSorted([1, 3, 2]) == false
+isSorted(["apple", "banana", "cherry"]) == true
+```
+This custom function is importable in your own Expr code by importing github.com/polds/expr-playground/functions and
+adding `functions.IsSorted()` to your environment. The library supports sorting on types that satisfy the 
+`sort.Interface` interface.
+
+
+
 ## Development
 
 Build the Wasm binary:

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
+	"github.com/polds/expr-playground/functions"
 )
 
 type RunResponse struct {
@@ -30,12 +31,14 @@ type RunResponse struct {
 
 var exprEnvOptions = []expr.Option{
 	expr.AsAny(),
+	// Inject a custom isSorted function into the environment.
+	functions.IsSorted(),
 }
 
 // Eval evaluates the expr expression against the given input.
 func Eval(exp string, input map[string]any) (string, error) {
-	exprEnvOptions = append(exprEnvOptions, expr.Env(input))
-	program, err := expr.Compile(exp, exprEnvOptions...)
+	localOpts := append([]expr.Option{expr.Env(input)}, exprEnvOptions...)
+	program, err := expr.Compile(exp, localOpts...)
 	if err != nil {
 		return "", fmt.Errorf("failed to compile the Expr expression: %w", err)
 	}

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -1,4 +1,5 @@
 // Copyright 2023 Undistro Authors
+// Modifications Fork and conversion to Expr Copyright 2024 Peter Olds <me@polds.dev>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -73,11 +74,8 @@ func TestEval(t *testing.T) {
 		},
 		{
 			name: "list",
-			// For some reason object.items == sort(object.items) is false here, but the playground evaluates it as true.
-			// Needs further investigation.
-			exp:  `object.items == sort(object.items) && sum(object.items) == 6 && sort(object.items)[-1] == 3 && findIndex(object.items, # == 1) == 0`,
+			exp:  `isSorted(object.items) && sum(object.items) == 6 && sort(object.items)[-1] == 3 && findIndex(object.items, # == 1) == 0`,
 			want: true,
-			skip: true, // https://github.com/polds/expr-playground/issues/5
 		},
 		{
 			name: "optional",
@@ -183,6 +181,7 @@ func TestEval(t *testing.T) {
 			skip: true, // https://github.com/polds/expr-playground/issues/20
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.skip {
@@ -190,7 +189,6 @@ func TestEval(t *testing.T) {
 			}
 
 			got, err := Eval(tt.exp, input)
-
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Eval() got error = %v, wantErr %t", err, tt.wantErr)
 				return

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -74,7 +74,7 @@ func TestEval(t *testing.T) {
 		},
 		{
 			name: "list",
-			exp:  `isSorted(object.items) && sum(object.items) == 6 && sort(object.items)[-1] == 3 && findIndex(object.items, # == 1) == 0`,
+			exp:  `isSorted(object.items) && sum(object.items) == 6 && object.items[-1] == 3 && findIndex(object.items, # == 1) == 0`,
 			want: true,
 		},
 		{

--- a/examples.yaml
+++ b/examples.yaml
@@ -17,12 +17,14 @@ examples:
   - name: "default"
     expr: |
       // Welcome to the Expr Playground!
-      // Expr Playground is an interactive WebAssembly powered environment to explore and experiment with the Expr-lang.
+      // Expr Playground is an interactive WebAssembly powered environment to explore and experiment with Expr-lang.
       //
       // - Write your Expr expression here
       // - Use the area on the side for input data, in YAML or JSON format
       // - Press 'Run' to evaluate your Expr expression against the input data
       // - Explore our collection of examples for inspiration
+      //
+      // See the README on Github for information about what custom functions are available in the context.
 
       account.balance >= transaction.withdrawal
           || (account.overdraftProtection

--- a/functions/doc.go
+++ b/functions/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Undistro Authors
+// Copyright 2024 Peter Olds <me@polds.dev>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,22 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
-
-import (
-	"flag"
-	"log"
-	"net/http"
-)
-
-var (
-	listen = flag.String("listen", ":8080", "listen address")
-	dir    = flag.String("dir", ".", "directory to serve")
-)
-
-func main() {
-	flag.Parse()
-	log.Printf("listening on %s...", *listen)
-	err := http.ListenAndServe(*listen, http.FileServer(http.Dir(*dir)))
-	log.Fatalln(err)
-}
+// Package functions provides custom importable functions for Expr runtimes that may be injected into your Expr
+// runtime environments.
+package functions

--- a/functions/is_sorted.go
+++ b/functions/is_sorted.go
@@ -1,0 +1,128 @@
+// Copyright 2024 Peter Olds <me@polds.dev>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"cmp"
+	"fmt"
+	"reflect"
+	"slices"
+	"sort"
+
+	"github.com/expr-lang/expr"
+)
+
+// IsSorted provides the isSorted function as an Expr function. It will verify that the provided type
+// is sorted ascending. It supports the following types:
+// - Injected types that support the sort.Interface
+// - []int
+// - []float64
+// - []string
+//
+// Usage:
+//
+//	// Inject into your environment.
+//	_, err := expr.Compile(`foo`, expr.Env(nil), functions.ExprIsSorted())
+//
+// Expression:
+//
+//	isSorted([1, 2, 3])
+//	isSorted(["a", "b", "c"])
+//	isSorted([1.0, 2.0, 3.0])
+//	isSorted(myCustomType) // myCustomType must implement sort.Interface
+func IsSorted() expr.Option {
+	return expr.Function("isSorted", func(params ...any) (any, error) {
+		if len(params) != 1 {
+			return false, fmt.Errorf("expected one parameter, got %d", len(params))
+		}
+		return isSorted(params[0])
+	},
+		new(func(sort.Interface) (bool, error)),
+		new(func([]any) (bool, error)),
+		new(func([]int) (bool, error)),
+		new(func([]float64) (bool, error)),
+		new(func([]string) (bool, error)),
+	)
+}
+
+// isSorted attempts to determine if v is sortable, first by determine if it satisfies the sort.Interface interface,
+// then by checking if it is a slice of a sortable type. If the type is a slice of type []any pass it to the
+// isSliceSorted method which builds a new slice of the correct type and validates that it is sorted.
+func isSorted(v any) (any, error) {
+	if v == nil {
+		return false, nil
+	}
+
+	switch t := v.(type) {
+	case sort.Interface:
+		return sort.IsSorted(t), nil
+
+	// There are cases where Expr is passing around an []any instead of a []int, []float64, or []string.
+	// This logic will attempt to do its own sorting to determine if the slice is sorted.
+	case []any:
+		return isSliceSorted(t)
+	case []int:
+		return slices.IsSorted(t), nil
+	case []float64:
+		return slices.IsSorted(t), nil
+	case []string:
+		return slices.IsSorted(t), nil
+	}
+	return false, fmt.Errorf("type %s is not sortable", reflect.TypeOf(v))
+}
+
+func convertTo[E cmp.Ordered](x any) (E, error) {
+	var r E
+	v, ok := x.(E)
+	if !ok {
+		return r, fmt.Errorf("mis-typed slice, expected %T, got %T", r, x)
+	}
+	return v, nil
+}
+
+func less[E cmp.Ordered](vv []any) (bool, error) {
+	for i := len(vv) - 1; i > 0; i-- {
+		l, err := convertTo[E](vv[i-1])
+		if err != nil {
+			return false, err
+		}
+		h, err := convertTo[E](vv[i])
+		if err != nil {
+			return false, err
+		}
+		if cmp.Less(h, l) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// isSliceSorted attempts to determine if v is a slice of a sortable type.
+// Instead of building a slice it just walks the slice and validates that it is sorted. The first unsorted element
+// causes the function to return false.
+// Expr only supports int, float, and string types.
+func isSliceSorted(vv []any) (bool, error) {
+	// We have to peek the first element to determine the type of the slice.
+	switch t := vv[0].(type) {
+	case int:
+		return less[int](vv)
+	case float64:
+		return less[float64](vv)
+	case string:
+		return less[string](vv)
+	default:
+		return false, fmt.Errorf("unsupported type %T", t)
+	}
+}

--- a/functions/is_sorted_test.go
+++ b/functions/is_sorted_test.go
@@ -1,0 +1,296 @@
+// Copyright 2024 Peter Olds <me@polds.dev>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+func (p Person) String() string {
+	return fmt.Sprintf("%s: %d", p.Name, p.Age)
+}
+
+// ByAge implements sort.Interface for []Person based on
+// the Age field.
+type ByAge []Person
+
+func (a ByAge) Len() int           { return len(a) }
+func (a ByAge) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByAge) Less(i, j int) bool { return a[i].Age < a[j].Age }
+
+func Test_isSorted(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		sorted, err := isSorted(nil)
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("sort.Interface - not sorted", func(t *testing.T) {
+		people := []Person{
+			{"Bob", 31},
+			{"John", 42},
+			{"Michael", 17},
+			{"Jenny", 26},
+		}
+		sorted, err := isSorted(ByAge(people))
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("sort.Interface - sorted", func(t *testing.T) {
+		people := []Person{
+			{"Michael", 17},
+			{"Jenny", 26},
+			{"Bob", 31},
+			{"John", 42},
+		}
+		sorted, err := isSorted(ByAge(people))
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("any - int slice - not sorted", func(t *testing.T) {
+		sorted, err := isSorted([]any{5, 4, 3, 2, 1})
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("any - int slice - sorted", func(t *testing.T) {
+		sorted, err := isSorted([]any{1, 2, 3, 4, 5})
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("any - mis-typed int slice", func(t *testing.T) {
+		sorted, err := isSorted([]any{1, 2, 3, "4", 5})
+		require.Error(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("any - float slice - not sorted", func(t *testing.T) {
+		sorted, err := isSorted([]any{5.0, 4.0, 3.0, 2.0, 1.0})
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("any - float slice - sorted", func(t *testing.T) {
+		sorted, err := isSorted([]any{1.0, 2.0, 3.0, 4.0, 5.0})
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("any - mis-typed float slice", func(t *testing.T) {
+		sorted, err := isSorted([]any{1.0, 2.0, 3.0, "4.0", 5.0})
+		require.Error(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("any - string slice - not sorted", func(t *testing.T) {
+		sorted, err := isSorted([]any{"5", "4", "3", "2", "1"})
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("any - string slice - sorted", func(t *testing.T) {
+		sorted, err := isSorted([]any{"1", "2", "3", "4", "5"})
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("any - mis-typed string slice", func(t *testing.T) {
+		sorted, err := isSorted([]any{"1", "2", "3", 4, "5"})
+		require.Error(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("any - unsupported type", func(t *testing.T) {
+		sorted, err := isSorted([]any{Person{"Bob", 31}})
+		require.Error(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("int slice - not sorted", func(t *testing.T) {
+		sorted, err := isSorted([]int{5, 4, 3, 2, 1})
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("int slice - sorted", func(t *testing.T) {
+		sorted, err := isSorted([]int{1, 2, 3, 4, 5})
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("float slice - not sorted", func(t *testing.T) {
+		sorted, err := isSorted([]float64{5.0, 4.0, 3.0, 2.0, 1.0})
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("float slice - sorted", func(t *testing.T) {
+		sorted, err := isSorted([]float64{1.0, 2.0, 3.0, 4.0, 5.0})
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("string slice - not sorted", func(t *testing.T) {
+		sorted, err := isSorted([]string{"5", "4", "3", "2", "1"})
+		require.NoError(t, err)
+		assert.False(t, sorted.(bool))
+	})
+	t.Run("string slice - sorted", func(t *testing.T) {
+		sorted, err := isSorted([]string{"1", "2", "3", "4", "5"})
+		require.NoError(t, err)
+		assert.True(t, sorted.(bool))
+	})
+	t.Run("unsupported type", func(t *testing.T) {
+		sorted, err := isSorted(Person{"Bob", 31})
+		require.Error(t, err)
+		assert.False(t, sorted.(bool))
+	})
+}
+
+func TestIsSorted(t *testing.T) {
+	tests := []struct {
+		name           string
+		exp            string
+		want           bool
+		wantCompileErr bool
+		wantRuntimeErr bool
+	}{
+		{
+			name: "nil",
+			exp:  `isSorted(nil)`,
+			want: false,
+		},
+		{
+			name: "sort.Interface - not sorted",
+			exp:  `isSorted(people_unsorted)`,
+		},
+		{
+			name: "sort.Interface - sorted",
+			exp:  `isSorted(people_sorted)`,
+			want: true,
+		},
+		{
+			name: "int slice - not sorted",
+			exp:  `isSorted(ints_unsorted)`,
+		},
+		{
+			name: "int slice - sorted",
+			exp:  `isSorted(ints_sorted)`,
+			want: true,
+		},
+		{
+			name: "float slice - not sorted",
+			exp:  `isSorted(floats_unsorted)`,
+		},
+		{
+			name: "float slice - sorted",
+			exp:  `isSorted(floats_sorted)`,
+			want: true,
+		},
+		{
+			name: "string slice - not sorted",
+			exp:  `isSorted(strings_unsorted)`,
+		},
+		{
+			name: "string slice - sorted",
+			exp:  `isSorted(strings_sorted)`,
+			want: true,
+		},
+		{
+			name: "any - int slice - not sorted",
+			exp:  `isSorted(any_unsorted)`,
+		},
+		{
+			name: "any - int slice - sorted",
+			exp:  `isSorted(any_sorted)`,
+			want: true,
+		},
+		{
+			name:           "any - mis-typed int slice",
+			exp:            `isSorted(any_mixed_slice)`,
+			wantRuntimeErr: true,
+		},
+		{
+			name:           "unsupported type",
+			exp:            `isSorted(v)`,
+			wantCompileErr: true,
+		},
+		{
+			name:           "no argument",
+			exp:            `isSorted()`,
+			wantCompileErr: true,
+		},
+		{
+			name:           "too many arguments",
+			exp:            `isSorted(ints_sorted, ints_sorted)`,
+			wantCompileErr: true,
+		},
+	}
+
+	people := []Person{
+		{"Michael", 17},
+		{"Jenny", 26},
+		{"Bob", 31},
+		{"John", 42},
+	}
+	input := map[string]any{
+		"people_sorted": ByAge(people),
+		"people_unsorted": func() ByAge {
+			ii := make([]Person, len(people))
+			copy(ii, people)
+			ii[0], ii[1] = ii[1], ii[0]
+			return ii
+		}(),
+		"ints_sorted":      []int{1, 2, 3, 4, 5},
+		"ints_unsorted":    []int{5, 4, 3, 2, 1},
+		"floats_sorted":    []float64{1.0, 2.0, 3.0, 4.0, 5.0},
+		"floats_unsorted":  []float64{5.0, 4.0, 3.0, 2.0, 1.0},
+		"strings_sorted":   []string{"1", "2", "3", "4", "5"},
+		"strings_unsorted": []string{"5", "4", "3", "2", "1"},
+		"any_unsorted":     []any{5, 4, 3, 2, 1},
+		"any_sorted":       []any{1, 2, 3, 4, 5},
+		"any_mixed_slice":  []any{1, 2, 3, "4", 5},
+		"v":                true,
+	}
+	opts := []expr.Option{
+		expr.Env(input),
+		expr.AsBool(),
+		expr.DisableAllBuiltins(),
+		IsSorted(),
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			program, err := expr.Compile(tc.exp, opts...)
+			if tc.wantCompileErr && err == nil {
+				require.Error(t, err)
+			}
+			if !tc.wantCompileErr && err != nil {
+				require.NoError(t, err)
+			}
+			if tc.wantCompileErr {
+				return
+			}
+
+			got, err := expr.Run(program, input)
+			if tc.wantRuntimeErr && err == nil {
+				require.Error(t, err)
+			}
+			if !tc.wantRuntimeErr && err != nil {
+				require.NoError(t, err)
+			}
+			if tc.wantRuntimeErr {
+				return
+			}
+			assert.IsType(t, tc.want, got)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,14 @@ go 1.21
 require (
 	github.com/expr-lang/expr v1.15.8
 	github.com/google/go-cmp v0.6.0
+	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )


### PR DESCRIPTION
Provide a custom `isSorted` function for determining whether a slice is sorted ascending.

Inject the function into the playground, and fix the test that needs to verify sort order.

Usage:
`isSorted(["a", "b", "c"]) == true`

fixes #5

